### PR TITLE
No deploy on TEST_ONLY

### DIFF
--- a/webapp.js
+++ b/webapp.js
@@ -439,7 +439,6 @@ function registerEvents(emitter) {
             if (err && err.phase !== 'cleanup') {
               logger.debug("Failure in phase %s, running cleanup and failing build", err.phase)
               var runCleanup = f[phases.indexOf('cleanup')]
-              if (!runCleanup) return complete(err.code, null, err.tasks, done)
               return runCleanup(function(e) {
                 complete(err.code, null, err.tasks, done)
               })


### PR DESCRIPTION
### Bugfixes
- deploy scripts no longer run on a TEST_ONLY job.
- script was dying horribly if there's no cleanup script provided

fixes Strider-CD/strider#91

extracted this from [More phases, prevent deploy on TEST_ONLY](3)
