### PR TITLE
bugfix; noop on TEST_ONLY deploy phase

### DIFF
--- a/webapp.js
+++ b/webapp.js
@@ -362,6 +362,7 @@ function registerEvents(emitter) {
         phases.forEach(function(phase) {
           // skip deploy on TEST_ONLY
           if (data.job_type === TEST_ONLY && phase === 'deploy') {
+            f.push(function(cb) { return cb(null, []); });
             return;
           }
           f.push(function(cb) {


### PR DESCRIPTION
bugfix; this is the issue I was having with runCleanup. fixes strider-cd/strider#103

to get runcleanup we ask for `var runCleanup = f[phases.indexOf('cleanup')]`, and deploy was being totally skipped, so `f` had a length of 3 not 4.
