### PR TITLE
Restore missing comma in .jshintrc

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -5,7 +5,7 @@
   "node": true,
   "-W024": false,
   "-W069": false,
-  "undef": true
+  "undef": true,
   "predef": [
     "describe",
     "it",


### PR DESCRIPTION
A tiny problem I found while working on the other pull request :smile: