### PR TITLE
[wip] Configure the number of preserved data directories.

### DIFF
--- a/config/config.html
+++ b/config/config.html
@@ -10,7 +10,7 @@
 
 <p>
   Preserve the data directories from
-  <input class="inline-text" type="number" ng-model="config.concurrentJobs" placeholder="1">
+  <input class="inline-number" type="number" ng-model="config.concurrentJobs" placeholder="1">
   previous builds.
 </p>
 

--- a/config/config.html
+++ b/config/config.html
@@ -10,7 +10,7 @@
 
 <p>
   Preserve the data directories from
-  <input type="number" ng-model="config.concurrentJobs" placeholder="1">
+  <input class="inline-text" type="number" ng-model="config.concurrentJobs" placeholder="1">
   previous builds.
 </p>
 

--- a/config/config.html
+++ b/config/config.html
@@ -3,7 +3,15 @@
   Jobs are run on the same machine as the main strider instance, in a
   child process. This is the simplest option, but offers no security nor isolation.
   <strong>Only test trusted projects</strong> using this
-  runner.  
+  runner.
   If you need isolation, check out <a href="https://github.com/Strider-CD/strider-docker-runner">Docker
   Runner</a>.
 </p>
+
+<p>
+  Preserve the data directories from
+  <input type="number" ng-model="config.concurrentJobs" placeholder="1">
+  previous builds.
+</p>
+
+<button class="btn btn-primary" ng-click="save()">Save</button>

--- a/config/config.html
+++ b/config/config.html
@@ -10,7 +10,7 @@
 
 <p>
   Preserve the data directories from
-  <input class="inline-number" type="number" ng-model="config.concurrentJobs" placeholder="1">
+  <input class="inline-number" type="number" ng-model="config.recentBuilds" placeholder="1">
   previous builds.
 </p>
 

--- a/config/config.less
+++ b/config/config.less
@@ -1,5 +1,5 @@
 #runner-simple-runner {
-  input[type=number] {
+  input.inline-text {
     width: 3em;
     vertical-align: baseline;
   }

--- a/config/config.less
+++ b/config/config.less
@@ -1,5 +1,5 @@
 #runner-simple-runner {
-  input.inline-text {
+  input.inline-number {
     width: 3em;
     vertical-align: baseline;
   }

--- a/config/config.less
+++ b/config/config.less
@@ -1,0 +1,6 @@
+#runner-simple-runner {
+  input[type=number] {
+    width: 3em;
+    vertical-align: baseline;
+  }
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -60,7 +60,7 @@ function Runner(emitter, config) {
     pluginDir: path.join(__dirname, '../node_modules'),
     dataDir: process.env.STRIDER_CLONE_DEST || dotStrider,
     concurrentJobs: parseInt(process.env.CONCURRENT_JOBS || '1', 10) || 1,
-    defaultRecentBuilds: parseInt(process.env.DEFAULT_RECENT_BUILDS || '0', 10) || 0,
+    defaultRecentBuilds: parseInt(process.env.DEFAULT_RECENT_BUILDS || '1', 10) || 1,
   }, config)
   this.emitter = emitter
   this.log = this.config.logger.log
@@ -303,12 +303,16 @@ Runner.prototype = {
       recentBuilds = self.config.defaultRecentBuilds
     }
 
-    self.log('Preserving the most recent ' + recentBuilds + ' builds within ' + branchBase + '.')
+    recentBuilds = Math.max(recentBuilds, 1)
+
+    if (recentBuilds > 1) {
+      self.log('Preserving the most recent ' + recentBuilds + ' builds within ' + branchBase + '.')
+    }
 
     // Keep around N most recent build directories for this branch.
     // The default is 0, ie wipe at start of each run.
     // Later, this can be configurable in the UI.
-    keeper({baseDir: branchBase, count: recentBuilds}, function(err) {
+    keeper({baseDir: branchBase, count: recentBuilds - 1}, function(err) {
       if (err) return next(err);
 
       initJobDirs(branchBase, job, cache.base, jobDirsReady)

--- a/lib/index.js
+++ b/lib/index.js
@@ -60,6 +60,7 @@ function Runner(emitter, config) {
     pluginDir: path.join(__dirname, '../node_modules'),
     dataDir: process.env.STRIDER_CLONE_DEST || dotStrider,
     concurrentJobs: parseInt(process.env.CONCURRENT_JOBS || '1', 10) || 1,
+    defaultRecentBuilds: parseInt(process.env.DEFAULT_RECENT_BUILDS || '0', 10) || 0,
   }, config)
   this.emitter = emitter
   this.log = this.config.logger.log
@@ -296,12 +297,19 @@ Runner.prototype = {
     var projectName = job.project.name.replace('/', '-')
       , branchName = branchFromJob(job).replace('/', '-')
       , branchBase = path.join(self.config.dataDir, 'data', projectName + '-' + branchName)
+      , recentBuilds = config.runner.config.recentBuilds
+
+    if (typeof recentBuilds === 'undefined') {
+      recentBuilds = self.config.defaultRecentBuilds
+    }
+
+    self.log('Preserving the most recent ' + recentBuilds + ' builds within ' + branchBase + '.')
 
     // Keep around N most recent build directories for this branch.
     // The default is 0, ie wipe at start of each run.
     // Later, this can be configurable in the UI.
-    keeper({baseDir: branchBase, count: 0}, function(err) {
-      if (err) throw err;
+    keeper({baseDir: branchBase, count: recentBuilds}, function(err) {
+      if (err) return next(err);
 
       initJobDirs(branchBase, job, cache.base, jobDirsReady)
     })


### PR DESCRIPTION
Adds a control to the runner's configuration page to adjust the number of most recent data directories to preserve for each job.

- [x] Add a control to the configuration page.
- [x] Actually use the configuration value.

Fixes #28.