### PR TITLE
Set default environment variables

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -372,7 +372,10 @@ Runner.prototype = {
           return next(err);
         }
 
-        var env = {};
+        var env = {
+          CI: 'true',
+          STRIDER: 'true',
+        };
 
         if (config.envKeys) {
           env.STRIDER_SSH_PUB = config.pubkey;


### PR DESCRIPTION
This allows code being run by the CI server to detect that it's running inside a CI server.

The `CI` environment variable is exposed by most major CI servers, but having a vendor specific environment variable (i.e. `STRIDER`) is also common practice.

For details see issue https://github.com/Strider-CD/strider/issues/892

This PR was created instead of https://github.com/Strider-CD/strider/pull/1045